### PR TITLE
Change PHP version constraint to allow PHP 8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2022-08-17
+### Changed
+- Change PHP version constraint to allow PHP 8.1.
+
 ## [1.0.2] - 2022-03-09
 ### Fixed
 - Fixed the syntex error in system.xml file (#3)

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "homepage": "https://tracedock.com",
     "require": {
-        "php": "^7.4",
+        "php": "^7.4 || ^8.1",
         "magento/framework": "*",
         "magento/module-sales": "*",
         "magento/module-asynchronous-operations": "*"


### PR DESCRIPTION
There's a PHP version constraint in the `composer.json` limiting its use to PHP 7.4. This PR changed the version constraint to allow PHP 8.1, which is required for Magento 2.4.4/2.4.5.

Relates to #5 

@igorwulff 